### PR TITLE
PETSc configure failing

### DIFF
--- a/config/configure.py
+++ b/config/configure.py
@@ -513,7 +513,6 @@ def petsc_configure(configure_options):
     +'*******************************************************************************\n'
     se  = str(e)
 
-  framework.logClear()
   print(msg)
   if not framework is None:
     framework.logClear()


### PR DESCRIPTION
There seems to be a redundant framework.logClear() in petsc/config/configure.py.  This commit removes it.